### PR TITLE
gntdev: add new ioctls to map dmabuf to existing fd

### DIFF
--- a/tools/include/xen-sys/Linux/gntdev.h
+++ b/tools/include/xen-sys/Linux/gntdev.h
@@ -328,4 +328,49 @@ struct ioctl_gntdev_dmabuf_imp_to_refs_v2 {
     uint32_t refs[1];
 };
 
+/*
+ * Fd mapping ioctls allows to map @fd to @refs.
+ *
+ * Allows gntdev to map scatter-gather table to the existing dma-buf
+ * file destriptor. It provides the same functionality as
+ * DMABUF_EXP_FROM_REFS_V2 ioctls,
+ * but maps sc table on top of the existing buffer memory, instead of
+ * allocting memory. This is useful when exporter should work with external
+ * buffer.
+ */
+
+#define IOCTL_GNTDEV_DMABUF_MAP_REFS_TO_BUF \
+       _IOC(_IOC_NONE, 'G', 15, \
+         sizeof(struct ioctl_gntdev_dmabuf_map_refs_to_buf))
+struct ioctl_gntdev_dmabuf_map_refs_to_buf {
+       /* IN parameters. */
+       /* Specific options for this dma-buf: see GNTDEV_DMA_FLAG_XXX. */
+       uint32_t flags;
+       /* Number of grant references in @refs array. */
+       uint32_t count;
+       /* Offset of the data in the dma-buf. */
+       uint32_t data_ofs;
+       /* File descriptor of the dma-buf. */
+       uint32_t fd;
+       /* The domain ID of the grant references to be mapped. */
+       uint32_t domid;
+       /* Variable IN parameter. */
+       /* Array of grant references of size @count. */
+       uint32_t refs[1];
+};
+
+/*
+ * This will close all references to the mapped buffer with file descriptor
+ * @fd, so it can be released by the owner. This is only valid for buffers
+ * created with IOCTL_GNTDEV_DMABUF_MAP_REFS_TO_BUF.
+ */
+#define IOCTL_GNTDEV_DMABUF_MAP_RELEASE \
+       _IOC(_IOC_NONE, 'G', 16, \
+            sizeof(struct ioctl_gntdev_dmabuf_imp_release))
+struct ioctl_gntdev_dmabuf_map_release {
+       /* IN parameters */
+       uint32_t fd;
+       uint32_t reserved;
+};
+
 #endif /* __LINUX_PUBLIC_GNTDEV_H__ */

--- a/tools/include/xengnttab.h
+++ b/tools/include/xengnttab.h
@@ -335,6 +335,21 @@ int xengnttab_dmabuf_exp_from_refs_v2(xengnttab_handle *xgt, uint32_t domid,
                                       const uint32_t *refs, uint32_t *fd,
                                       uint32_t data_ofs);
 
+/**
+ * Map grant references @refs of count @count provided
+ * by the foreign domain @domid with flags @flags to the dma buffer [1],
+ * pointed by @fd file decriptor.
+ * Accepts @data_ofs offset of the data in the buffer.
+ *
+ * Returns 0 if dma-buf was mapped successfully.
+ *
+ * [1] https://elixir.bootlin.com/linux/latest/source/Documentation/driver-api/dma-buf.rst
+ */
+int xengnttab_dmabuf_map_refs_to_buf(xengnttab_handle *xgt, uint32_t domid,
+                                      uint32_t flags, uint32_t count,
+                                      const uint32_t *refs, uint32_t fd,
+                                      uint32_t data_ofs);
+
 /*
  * This will block until the dma-buf with the file descriptor @fd is
  * released. This is only valid for buffers created with
@@ -368,6 +383,13 @@ int xengnttab_dmabuf_imp_to_refs_v2(xengnttab_handle *xgt, uint32_t domid,
  * IOCTL_GNTDEV_DMABUF_IMP_TO_REFS.
  */
 int xengnttab_dmabuf_imp_release(xengnttab_handle *xgt, uint32_t fd);
+
+/*
+ * This will close all references to mapped buffer, so it can be
+ * released by the owner. This is only valid for buffers created with
+ * IOCTL_GNTDEV_DMABUF_MAP_REFS_TO_BUF.
+ */
+int xengnttab_dmabuf_map_release(xengnttab_handle *xgt, uint32_t fd);
 
 /*
  * Grant Sharing Interface (allocating and granting pages to others)

--- a/tools/libs/gnttab/freebsd.c
+++ b/tools/libs/gnttab/freebsd.c
@@ -327,6 +327,14 @@ int osdep_gnttab_dmabuf_exp_from_refs_v2(xengnttab_handle *xgt, uint32_t domid,
     abort();
 }
 
+int osdep_gnttab_dmabuf_map_refs_to_buf(xengnttab_handle *xgt,
+                                         uint32_t domid, uint32_t flags,
+                                         uint32_t count, const uint32_t *refs,
+                                         uint32_t dmabuf_fd, uint32_t data_ofs)
+{
+    abort();
+}
+
 int osdep_gnttab_dmabuf_exp_wait_released(xengnttab_handle *xgt,
                                           uint32_t fd, uint32_t wait_to_ms)
 {
@@ -347,6 +355,11 @@ int osdep_gnttab_dmabuf_imp_to_refs_v2(xengnttab_handle *xgt, uint32_t domid,
 }
 
 int osdep_gnttab_dmabuf_imp_release(xengnttab_handle *xgt, uint32_t fd)
+{
+    abort();
+}
+
+int osdep_gnttab_dmabuf_map_release(xengnttab_handle *xgt, uint32_t fd)
 {
     abort();
 }

--- a/tools/libs/gnttab/gnttab_core.c
+++ b/tools/libs/gnttab/gnttab_core.c
@@ -153,6 +153,15 @@ int xengnttab_dmabuf_exp_from_refs_v2(xengnttab_handle *xgt, uint32_t domid,
                                                 refs, fd, data_ofs);
 }
 
+int xengnttab_dmabuf_map_refs_to_buf(xengnttab_handle *xgt, uint32_t domid,
+                                      uint32_t flags, uint32_t count,
+                                      const uint32_t *refs, uint32_t fd,
+                                      uint32_t data_ofs)
+{
+    return osdep_gnttab_dmabuf_map_refs_to_buf(xgt, domid, flags, count,
+                                                refs, fd, data_ofs);
+}
+
 int xengnttab_dmabuf_exp_wait_released(xengnttab_handle *xgt, uint32_t fd,
                                        uint32_t wait_to_ms)
 {
@@ -176,6 +185,11 @@ int xengnttab_dmabuf_imp_to_refs_v2(xengnttab_handle *xgt, uint32_t domid,
 int xengnttab_dmabuf_imp_release(xengnttab_handle *xgt, uint32_t fd)
 {
     return osdep_gnttab_dmabuf_imp_release(xgt, fd);
+}
+
+int xengnttab_dmabuf_map_release(xengnttab_handle *xgt, uint32_t fd)
+{
+    return osdep_gnttab_dmabuf_map_release(xgt, fd);
 }
 /*
  * Local variables:

--- a/tools/libs/gnttab/libxengnttab.map
+++ b/tools/libs/gnttab/libxengnttab.map
@@ -42,3 +42,9 @@ VERS_1.3 {
 		xengnttab_dmabuf_exp_from_refs_v2;
 		xengnttab_dmabuf_imp_to_refs_v2;
 } VERS_1.2;
+
+VERS_1.4 {
+    global:
+		xengnttab_dmabuf_map_refs_to_buf;
+		xengnttab_dmabuf_map_release;
+} VERS_1.3;

--- a/tools/libs/gnttab/private.h
+++ b/tools/libs/gnttab/private.h
@@ -41,6 +41,11 @@ int osdep_gnttab_dmabuf_exp_from_refs_v2(xengnttab_handle *xgt, uint32_t domid,
                                          const uint32_t *refs, uint32_t *fd,
                                          uint32_t data_ofs);
 
+int osdep_gnttab_dmabuf_map_refs_to_buf(xengnttab_handle *xgt,
+                                         uint32_t domid, uint32_t flags,
+                                         uint32_t count, const uint32_t *refs,
+                                         uint32_t fd, uint32_t data_ofs);
+
 int osdep_gnttab_dmabuf_exp_wait_released(xengnttab_handle *xgt,
                                           uint32_t fd, uint32_t wait_to_ms);
 
@@ -53,6 +58,7 @@ int osdep_gnttab_dmabuf_imp_to_refs_v2(xengnttab_handle *xgt, uint32_t domid,
                                        uint32_t *refs, uint32_t *data_ofs);
 
 int osdep_gnttab_dmabuf_imp_release(xengnttab_handle *xgt, uint32_t fd);
+int osdep_gnttab_dmabuf_map_release(xengnttab_handle *xgt, uint32_t fd);
 
 int osdep_gntshr_open(xengntshr_handle *xgs);
 int osdep_gntshr_close(xengntshr_handle *xgs);


### PR DESCRIPTION
Add new ioctls to allow gntdev to map scatter-gather table on
top of the existing dmabuf, referenced by file descriptor.

When using dma-buf exporter to create dma-buf with backing storage and
map it to the grant refs, provided from the domain, we've met a problem,
that several HW (i.MX8 gpu in our case) do not support external buffer
and requires backing storage to be created using it's native tools.
That's why new ioctls were added to be able to pass existing dma-buffer
fd as input parameter and use it as backing storage to export to refs.

Signed-off-by: Oleksii Moisieiev <oleksii_moisieiev@epam.com>