### PR TITLE
gntdev: add new api to map dmabuf to existing fd

### DIFF
--- a/tools/console/Makefile
+++ b/tools/console/Makefile
@@ -13,7 +13,7 @@ LDLIBS_xenconsoled += $(UTIL_LIBS)
 LDLIBS_xenconsoled += -lrt
 CONSOLE_CFLAGS-$(CONFIG_ARM) = -DCONFIG_ARM
 
-BIN      = xenconsoled xenconsole
+BIN      = xenconsoled xenconsole gnt_test
 
 .PHONY: all
 all: $(BIN)
@@ -32,6 +32,11 @@ daemon/main.o: daemon/_paths.h
 daemon/io.o: CFLAGS += $(CFLAGS_libxenevtchn) $(CFLAGS_libxengnttab) $(CFLAGS_libxenforeignmemory) $(CONSOLE_CFLAGS-y)
 xenconsoled: $(patsubst %.c,%.o,$(wildcard daemon/*.c))
 	$(CC) $(LDFLAGS) $^ -o $@ $(LDLIBS) $(LDLIBS_libxenevtchn) $(LDLIBS_libxengnttab) $(LDLIBS_libxenforeignmemory) $(LDLIBS_xenconsoled) $(APPEND_LDFLAGS)
+
+gnt.o: CFLAGS += $(CFLAGS_libxengnttab) $(CONSOLE_CFLAGS-y)
+
+gnt_test: gnt.o
+	$(CC) $(LDFLAGS) $^ -o $@ $(LDLIBS) $(LDLIBS_libxengnttab) $(APPEND_LDFLAGS)
 
 client/main.o: client/_paths.h
 xenconsole: $(patsubst %.c,%.o,$(wildcard client/*.c))

--- a/tools/console/gnt.c
+++ b/tools/console/gnt.c
@@ -1,0 +1,125 @@
+#include <bits/stdint-uintn.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <xengnttab.h>
+#include <xenctrl.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+struct drm_mode_destroy_dumb {
+	uint32_t handle;
+};
+
+/* create a dumb scanout buffer */
+struct drm_mode_create_dumb {
+	uint32_t height;
+	uint32_t width;
+	uint32_t bpp;
+	uint32_t flags;
+	/* handle, pitch, size will be returned */
+	uint32_t handle;
+	uint32_t pitch;
+	uint64_t size;
+};
+
+#define DRM_RDWR O_RDWR
+#define DRM_CLOEXEC O_CLOEXEC
+struct drm_prime_handle {
+	uint32_t handle;
+
+	/** Flags.. only applicable for handle->fd */
+	uint32_t flags;
+
+	/** Returned dmabuf file descriptor */
+	int32_t fd;
+};
+
+#define CREATE_DMABUF _IOR('a', 'a', uint32_t*)
+#define DESTROY_DMABUF _IO('a', 'b')
+#define DRM_IOCTL_MODE_CREATE_DUMB _IOWR('d', 0xB2, struct drm_mode_create_dumb)
+#define DRM_IOCTL_PRIME_HANDLE_TO_FD _IOWR('d', 0x2d, struct drm_prime_handle)
+#define DRM_IOCTL_MODE_DESTROY_DUMB _IOWR('d', 0xB4, struct drm_mode_destroy_dumb)
+#define CHRET(ret) \
+    do { \
+        printf("%d ret = %d\n", __LINE__, ret); \
+        if (ret) {\
+            printf("%d ret = %d\n", __LINE__, ret); \
+            goto close; \
+        } \
+    } while(0);
+
+int main(int argc, char **argv)
+{
+    int i, ret = 0;
+    xengnttab_handle *xgt;
+    uint32_t *refs;
+    uint32_t fd;
+    int chfd;
+    uint32_t domid;
+    struct drm_mode_create_dumb creq;
+    struct drm_mode_destroy_dumb dreq;
+    struct drm_prime_handle prime;
+
+    printf("argc %d\n", argc);
+    if (argc < 3)
+        return -EINVAL;
+
+    domid = atoi(argv[1]);
+    printf("domid = %d\n", domid);
+
+    refs = malloc(sizeof(uint32_t) * (argc - 2));
+    for (i = 2; i < argc; i++)
+    {
+        refs[i - 2] = atoi(argv[i]);
+        printf("g %d\n", refs[i - 2]);
+    }
+
+    xgt = xengnttab_open(NULL, 0);
+    if (!xgt) {
+        ret = -ENOMEM;
+        goto err;
+    }
+
+    chfd = open("/dev/dri/card0", 0);
+    if (!chfd)
+        goto err;
+
+    creq.width = 100;
+    creq.height =550;
+    creq.bpp = 32;
+    ret = ioctl(chfd, DRM_IOCTL_MODE_CREATE_DUMB, &creq);
+//    ret = ioctl(chfd, CREATE_DMABUF, (uint32_t *) &fd);
+    CHRET(ret);
+
+    printf("handle = %d\n", creq.handle);
+    prime.handle = creq.handle;
+
+    ret = ioctl(chfd, DRM_IOCTL_PRIME_HANDLE_TO_FD, &prime);
+    CHRET(ret);
+
+    fd = prime.fd;
+    printf("fd = %d\n", fd);
+
+    ret = xengnttab_dmabuf_map_refs_to_buf(xgt, domid, 0, argc - 2,
+            refs, fd, 0);
+    CHRET(ret);
+
+    ret = xengnttab_dmabuf_map_release(xgt, fd);
+    CHRET(ret);
+
+    close(fd);
+    dreq.handle = creq.handle;
+    ret = ioctl(chfd, DRM_IOCTL_MODE_DESTROY_DUMB, &dreq);
+    CHRET(ret);
+
+    ret = xengnttab_dmabuf_map_wait_released(xgt, fd, 1000);
+    CHRET(ret);
+
+    ret = xengnttab_close(xgt);
+    CHRET(ret);
+close:
+    close(chfd);
+err:
+    free(refs);
+    return ret;
+};

--- a/tools/include/xen-sys/Linux/gntdev.h
+++ b/tools/include/xen-sys/Linux/gntdev.h
@@ -328,4 +328,63 @@ struct ioctl_gntdev_dmabuf_imp_to_refs_v2 {
     uint32_t refs[1];
 };
 
+/*
+ * Fd mapping ioctls allows to map @fd to @refs.
+ *
+ * Allows gntdev to map scatter-gather table to the existing dma-buf
+ * file destriptor. It provides the same functionality as
+ * DMABUF_EXP_FROM_REFS_V2 ioctls,
+ * but maps sc table on top of the existing buffer memory, instead of
+ * allocting memory. This is useful when exporter should work with external
+ * buffer.
+ */
+
+#define IOCTL_GNTDEV_DMABUF_MAP_REFS_TO_BUF \
+       _IOC(_IOC_NONE, 'G', 15, \
+         sizeof(struct ioctl_gntdev_dmabuf_map_refs_to_buf))
+struct ioctl_gntdev_dmabuf_map_refs_to_buf {
+       /* IN parameters. */
+       /* Specific options for this dma-buf: see GNTDEV_DMA_FLAG_XXX. */
+       uint32_t flags;
+       /* Number of grant references in @refs array. */
+       uint32_t count;
+       /* Offset of the data in the dma-buf. */
+       uint32_t data_ofs;
+       /* File descriptor of the dma-buf. */
+       uint32_t fd;
+       /* The domain ID of the grant references to be mapped. */
+       uint32_t domid;
+       /* Variable IN parameter. */
+       /* Array of grant references of size @count. */
+       uint32_t refs[1];
+};
+
+/*
+ * This will close all references to the mapped buffer with file descriptor
+ * @fd, so it can be released by the owner. This is only valid for buffers
+ * created with IOCTL_GNTDEV_DMABUF_MAP_REFS_TO_BUF.
+ */
+#define IOCTL_GNTDEV_DMABUF_MAP_RELEASE \
+       _IOC(_IOC_NONE, 'G', 16, \
+            sizeof(struct ioctl_gntdev_dmabuf_map_release))
+struct ioctl_gntdev_dmabuf_map_release {
+       /* IN parameters */
+       uint32_t fd;
+       uint32_t reserved;
+};
+
+/*
+ * This will wait until gntdev release procedure is finished and buffer was
+ * released completely. This is only valid for buffers created with
+ * IOCTL_GNTDEV_DMABUF_EXP_REFS_TO_BUF.
+ */
+#define IOCTL_GNTDEV_DMABUF_MAP_WAIT_RELEASED \
+	_IOC(_IOC_NONE, 'G', 17, \
+	     sizeof(struct ioctl_gntdev_dmabuf_map_wait_released))
+struct ioctl_gntdev_dmabuf_map_wait_released {
+	/* IN parameters */
+	uint32_t fd;
+	uint32_t wait_to_ms;
+};
+
 #endif /* __LINUX_PUBLIC_GNTDEV_H__ */

--- a/tools/include/xengnttab.h
+++ b/tools/include/xengnttab.h
@@ -335,6 +335,21 @@ int xengnttab_dmabuf_exp_from_refs_v2(xengnttab_handle *xgt, uint32_t domid,
                                       const uint32_t *refs, uint32_t *fd,
                                       uint32_t data_ofs);
 
+/**
+ * Map grant references @refs of count @count provided
+ * by the foreign domain @domid with flags @flags to the dma buffer [1],
+ * pointed by @fd file decriptor.
+ * Accepts @data_ofs offset of the data in the buffer.
+ *
+ * Returns 0 if dma-buf was mapped successfully.
+ *
+ * [1] https://elixir.bootlin.com/linux/latest/source/Documentation/driver-api/dma-buf.rst
+ */
+int xengnttab_dmabuf_map_refs_to_buf(xengnttab_handle *xgt, uint32_t domid,
+                                      uint32_t flags, uint32_t count,
+                                      const uint32_t *refs, uint32_t fd,
+                                      uint32_t data_ofs);
+
 /*
  * This will block until the dma-buf with the file descriptor @fd is
  * released. This is only valid for buffers created with
@@ -368,6 +383,21 @@ int xengnttab_dmabuf_imp_to_refs_v2(xengnttab_handle *xgt, uint32_t domid,
  * IOCTL_GNTDEV_DMABUF_IMP_TO_REFS.
  */
 int xengnttab_dmabuf_imp_release(xengnttab_handle *xgt, uint32_t fd);
+
+/*
+ * This will release gntdev attachment to the provided buffer with file
+ * descriptor @fd, so it can be released by the owner. This is only valid
+ * for buffers created with IOCTL_GNTDEV_DMABUF_EXP_REFS_TO_BUF.
+ */
+int xengnttab_dmabuf_map_release(xengnttab_handle *xgt, uint32_t fd);
+
+/*
+ * This will wait until gntdev release procedure is finished and buffer was
+ * released completely. This is only valid for buffers created with
+ * IOCTL_GNTDEV_DMABUF_EXP_REFS_TO_BUF.
+ */
+int xengnttab_dmabuf_map_wait_released(xengnttab_handle *xgt, uint32_t fd,
+        uint32_t wait_to_ms);
 
 /*
  * Grant Sharing Interface (allocating and granting pages to others)

--- a/tools/libs/gnttab/Makefile
+++ b/tools/libs/gnttab/Makefile
@@ -2,7 +2,7 @@ XEN_ROOT = $(CURDIR)/../../..
 include $(XEN_ROOT)/tools/Rules.mk
 
 MAJOR    = 1
-MINOR    = 3
+MINOR    = 4
 
 SRCS-GNTTAB            += gnttab_core.c
 SRCS-GNTSHR            += gntshr_core.c

--- a/tools/libs/gnttab/freebsd.c
+++ b/tools/libs/gnttab/freebsd.c
@@ -327,6 +327,14 @@ int osdep_gnttab_dmabuf_exp_from_refs_v2(xengnttab_handle *xgt, uint32_t domid,
     abort();
 }
 
+int osdep_gnttab_dmabuf_map_refs_to_buf(xengnttab_handle *xgt,
+                                         uint32_t domid, uint32_t flags,
+                                         uint32_t count, const uint32_t *refs,
+                                         uint32_t dmabuf_fd, uint32_t data_ofs)
+{
+    abort();
+}
+
 int osdep_gnttab_dmabuf_exp_wait_released(xengnttab_handle *xgt,
                                           uint32_t fd, uint32_t wait_to_ms)
 {
@@ -347,6 +355,17 @@ int osdep_gnttab_dmabuf_imp_to_refs_v2(xengnttab_handle *xgt, uint32_t domid,
 }
 
 int osdep_gnttab_dmabuf_imp_release(xengnttab_handle *xgt, uint32_t fd)
+{
+    abort();
+}
+
+int osdep_gnttab_dmabuf_map_release(xengnttab_handle *xgt, uint32_t fd)
+{
+    abort();
+}
+
+int osdep_gnttab_dmabuf_map_wait_released(xengnttab_handle *xgt, uint32_t fd,
+        uint32_t wait_to_ms)
 {
     abort();
 }

--- a/tools/libs/gnttab/gnttab_core.c
+++ b/tools/libs/gnttab/gnttab_core.c
@@ -153,6 +153,15 @@ int xengnttab_dmabuf_exp_from_refs_v2(xengnttab_handle *xgt, uint32_t domid,
                                                 refs, fd, data_ofs);
 }
 
+int xengnttab_dmabuf_map_refs_to_buf(xengnttab_handle *xgt, uint32_t domid,
+                                      uint32_t flags, uint32_t count,
+                                      const uint32_t *refs, uint32_t fd,
+                                      uint32_t data_ofs)
+{
+    return osdep_gnttab_dmabuf_map_refs_to_buf(xgt, domid, flags, count,
+                                                refs, fd, data_ofs);
+}
+
 int xengnttab_dmabuf_exp_wait_released(xengnttab_handle *xgt, uint32_t fd,
                                        uint32_t wait_to_ms)
 {
@@ -176,6 +185,17 @@ int xengnttab_dmabuf_imp_to_refs_v2(xengnttab_handle *xgt, uint32_t domid,
 int xengnttab_dmabuf_imp_release(xengnttab_handle *xgt, uint32_t fd)
 {
     return osdep_gnttab_dmabuf_imp_release(xgt, fd);
+}
+
+int xengnttab_dmabuf_map_release(xengnttab_handle *xgt, uint32_t fd)
+{
+    return osdep_gnttab_dmabuf_map_release(xgt, fd);
+}
+
+int xengnttab_dmabuf_map_wait_released(xengnttab_handle *xgt, uint32_t fd,
+        uint32_t wait_to_ms)
+{
+    return osdep_gnttab_dmabuf_map_wait_released(xgt, fd, wait_to_ms);
 }
 /*
  * Local variables:

--- a/tools/libs/gnttab/libxengnttab.map
+++ b/tools/libs/gnttab/libxengnttab.map
@@ -42,3 +42,10 @@ VERS_1.3 {
 		xengnttab_dmabuf_exp_from_refs_v2;
 		xengnttab_dmabuf_imp_to_refs_v2;
 } VERS_1.2;
+
+VERS_1.4 {
+    global:
+		xengnttab_dmabuf_map_refs_to_buf;
+		xengnttab_dmabuf_map_release;
+		xengnttab_dmabuf_map_wait_released;
+} VERS_1.3;

--- a/tools/libs/gnttab/linux.c
+++ b/tools/libs/gnttab/linux.c
@@ -393,6 +393,50 @@ out:
     return rc;
 }
 
+int osdep_gnttab_dmabuf_map_refs_to_buf(xengnttab_handle *xgt, uint32_t domid,
+                                         uint32_t flags, uint32_t count,
+                                         const uint32_t *refs,
+                                         uint32_t dmabuf_fd,
+                                         uint32_t data_ofs)
+{
+    struct ioctl_gntdev_dmabuf_map_refs_to_buf *refs_to_fd = NULL;
+    int rc = -1;
+
+    if ( !count )
+    {
+        errno = EINVAL;
+        goto out;
+    }
+
+    refs_to_fd = malloc(sizeof(*refs_to_fd) +
+                          (count - 1) * sizeof(refs_to_fd->refs[0]));
+    if ( !refs_to_fd )
+    {
+        errno = ENOMEM;
+        goto out;
+    }
+
+    refs_to_fd->flags = flags;
+    refs_to_fd->count = count;
+    refs_to_fd->domid = domid;
+    refs_to_fd->data_ofs = data_ofs;
+    refs_to_fd->fd = dmabuf_fd;
+
+    memcpy(refs_to_fd->refs, refs, count * sizeof(refs_to_fd->refs[0]));
+
+    if ( (rc = ioctl(xgt->fd, IOCTL_GNTDEV_DMABUF_MAP_REFS_TO_BUF,
+                     refs_to_fd)) )
+    {
+        GTERROR(xgt->logger, "ioctl GNTDEV_DMABUF_MAP_REFS_TO_BUF failed");
+        goto out;
+    }
+
+    rc = 0;
+out:
+    free(refs_to_fd);
+    return rc;
+}
+
 int osdep_gnttab_dmabuf_exp_wait_released(xengnttab_handle *xgt,
                                           uint32_t fd, uint32_t wait_to_ms)
 {
@@ -504,6 +548,34 @@ int osdep_gnttab_dmabuf_imp_release(xengnttab_handle *xgt, uint32_t fd)
 
     if ( (rc = ioctl(xgt->fd, IOCTL_GNTDEV_DMABUF_IMP_RELEASE, &release)) )
         GTERROR(xgt->logger, "ioctl DMABUF_IMP_RELEASE failed");
+
+    return rc;
+}
+
+int osdep_gnttab_dmabuf_map_release(xengnttab_handle *xgt, uint32_t fd)
+{
+    struct ioctl_gntdev_dmabuf_map_release release;
+    int rc;
+
+    release.fd = fd;
+
+    if ( (rc = ioctl(xgt->fd, IOCTL_GNTDEV_DMABUF_MAP_RELEASE, &release)) )
+        GTERROR(xgt->logger, "ioctl DMABUF_MAP_RELEASE failed");
+
+    return rc;
+}
+
+int osdep_gnttab_dmabuf_map_wait_released(xengnttab_handle *xgt, uint32_t fd,
+        uint32_t wait_to_ms)
+{
+    struct ioctl_gntdev_dmabuf_map_wait_released release;
+    int rc;
+
+    release.fd = fd;
+    release.wait_to_ms = wait_to_ms;
+
+    if ( (rc = ioctl(xgt->fd, IOCTL_GNTDEV_DMABUF_MAP_WAIT_RELEASED, &release)) )
+        GTERROR(xgt->logger, "ioctl DMABUF_MAP_WAIT_RELEASED failed");
 
     return rc;
 }

--- a/tools/libs/gnttab/private.h
+++ b/tools/libs/gnttab/private.h
@@ -41,6 +41,11 @@ int osdep_gnttab_dmabuf_exp_from_refs_v2(xengnttab_handle *xgt, uint32_t domid,
                                          const uint32_t *refs, uint32_t *fd,
                                          uint32_t data_ofs);
 
+int osdep_gnttab_dmabuf_map_refs_to_buf(xengnttab_handle *xgt,
+                                         uint32_t domid, uint32_t flags,
+                                         uint32_t count, const uint32_t *refs,
+                                         uint32_t fd, uint32_t data_ofs);
+
 int osdep_gnttab_dmabuf_exp_wait_released(xengnttab_handle *xgt,
                                           uint32_t fd, uint32_t wait_to_ms);
 
@@ -53,6 +58,10 @@ int osdep_gnttab_dmabuf_imp_to_refs_v2(xengnttab_handle *xgt, uint32_t domid,
                                        uint32_t *refs, uint32_t *data_ofs);
 
 int osdep_gnttab_dmabuf_imp_release(xengnttab_handle *xgt, uint32_t fd);
+int osdep_gnttab_dmabuf_map_release(xengnttab_handle *xgt, uint32_t fd);
+int osdep_gnttab_dmabuf_map_wait_released(xengnttab_handle *xgt, uint32_t fd,
+                                       uint32_t wait_to_ms);
+
 
 int osdep_gntshr_open(xengntshr_handle *xgs);
 int osdep_gntshr_close(xengntshr_handle *xgs);


### PR DESCRIPTION
Add new api to allow gntdev to map scatter-gather table on top of the existing dmabuf, referenced by file descriptor.

When using dma-buf exporter to create dma-buf with backing storage and map it to the grant refs, provided from the domain, we've met a problem, that several HW (i.MX8 gpu in our case) do not support external buffer and requires backing storage to be created using it's native tools. That's why new calls were added to be able to pass existing dma-buffer fd as input parameter and use it as backing storage to export to refs.

Following calls were added:
xengnttab_dmabuf_map_refs_to_buf - map existing buffer as the backing storage and export it to the provided grant refs;
xengnttab_dmabuf_map_release - detach buffer from the grant table and set notification to unmap grant refs before releasing the external buffer. After this call the external buffer should be detroyed. xengnttab_dmabuf_map_wait_released - wait for timeout until buffer is completely destroyed and gnt refs unmapped so domain could free grant pages.

Signed-off-by: Oleksii Moisieiev <oleksii_moisieiev@epam.com>

b

Signed-off-by: Oleksii Moisieiev <oleksii_moisieiev@epam.com>